### PR TITLE
Mark all included files as dependencies for watch mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,8 @@ const plugin = (opts = {}) => {
                                         // push the dependency to watch tasks
                                         result.messages.push({
                                             type: "dependency",
-                                            file,
+											plugin: 'postcss-sass',
+											file,
                                             parent,
                                         });
                                     }
@@ -116,19 +117,40 @@ const plugin = (opts = {}) => {
                         (sassError, sassResult) =>
                             sassError ? reject(sassError) : resolve(sassResult)
                     )
-            ).then(({ css: sassCSS, map: sassMap }) =>
-                mergeSourceMaps(postMap.toJSON(), JSON.parse(sassMap)).then(
-                    (prev) => {
-                        // update root to post-node-sass ast
-                        result.root = parse(
-                            sassCSS.toString(),
-                            Object.assign({}, postConfig, {
-                                map: { prev },
-                            })
-                        );
-                    }
-                )
-            );
+				).then(({ css: sassCSS, map: sassMap, stats }) => {
+					const parent = pathResolve(postConfig.from);
+
+					// use stats.includedFiles to get the full list of dependencies.  Importer will not receive relative imports.  See https://github.com/sass/dart-sass/issues/574
+					for (const includedFile of stats.includedFiles) {
+						// strip the #sass suffix we added
+						const file = pathResolve(includedFile.replace(/#sass$/, ""));
+
+						// don't include the parent as a dependency of itself
+						if (file === parent) {
+							continue
+						}
+
+						// push the dependency to watch tasks
+						result.messages.push({
+							type: "dependency",
+							plugin: 'postcss-sass',
+							file,
+							parent,
+						});
+					}
+
+					return mergeSourceMaps(postMap.toJSON(), JSON.parse(sassMap)).then(
+						(prev) => {
+							// update root to post-node-sass ast
+							result.root = parse(
+								sassCSS.toString(),
+								Object.assign({}, postConfig, {
+									map: { prev },
+								})
+							);
+						}
+					);
+				});
         },
     };
 };


### PR DESCRIPTION
This is a fix for https://github.com/csstools/postcss-sass/issues/19.  I believe this stems from https://github.com/sass/dart-sass/issues/574 - TL;DR dart-sass does not perfectly match node-sass when it comes to the `importer` option.  In node-sass, _all_ imports are passed to the `importer` function and can be overridden.  This is a feature that `postcss-sass` was leveraging to gather dependencies for watch mode.  However, in dart-sass any imports that can be resolved as a _relative_ path do _not_ get passed to `importer`.  This is why most of our child imports are no longer watched.

The workaround is to do something like `sass-loader` does [here](https://github.com/webpack-contrib/sass-loader/blob/883edd2dc8d3aff3ceccf0b0a51234ec47d5f97d/src/index.js#L74-L81), which is to look at the `stats.includedFiles` from the dart-sass results, which includes a full list of the files that were encountered during compilation.